### PR TITLE
Change default theme to auto

### DIFF
--- a/components/Menu.vue
+++ b/components/Menu.vue
@@ -41,7 +41,7 @@
                         'button',
                         'button--toggle',
                         {
-                            'button--toggle-active': theme == null || theme === 'light',
+                            'button--toggle-active': theme === 'light',
                         }
                     ]"
                     @click.prevent="setTheme('light')"
@@ -67,7 +67,7 @@
                         'button',
                         'button--toggle',
                         {
-                            'button--toggle-active': theme === 'auto',
+                            'button--toggle-active': theme == null || theme === 'auto',
                         }
                     ]"
                     @click.prevent="setTheme('auto')"

--- a/pages/app.vue
+++ b/pages/app.vue
@@ -123,7 +123,7 @@
             },
 
             theme() {
-                return this.$store.state.theme || 'light';
+                return this.$store.state.theme || 'auto';
             },
         },
         mounted() {


### PR DESCRIPTION
Implements #52 by changing the value in `app` when there is no set theme from "light" to "auto". Also changes the `menu` component so auto is shown to be selected when the theme has been not been set.

This saves the dark theme users a few clicks, as the very first thing I did when I found the site was switching the theme to auto.