### PR TITLE
Add post shuffling

### DIFF
--- a/assets/Defer.js
+++ b/assets/Defer.js
@@ -1,0 +1,87 @@
+export default function (count = 20) {
+    return {
+        data() {
+            return {
+                displayPriority: 0,
+            };
+        },
+
+        mounted() {
+            this.runDisplayPriority();
+        },
+
+        computed: {
+            numShuffles() {
+                return this.$store.state.numShuffles;
+            },
+
+            layout() {
+                return this.$store.state.layout;
+            },
+
+            showNsfw() {
+                return this.$store.state.showNsfw;
+            },
+
+            filterNsfw() {
+                return this.$store.state.filterNsfw;
+            },
+        },
+
+        watch: {
+            // Watch the store values that cause the most intense operations 
+            // when they change so mounting posts can be deferred. The display 
+            // priority val has to be reset each time deferring is needed.
+            numShuffles: {
+                deep: false,
+                handler() {
+                    this.resetDisplayPriority();
+                },
+            },
+
+            layout: {
+                deep: false,
+                handler() {
+                    this.resetDisplayPriority();
+                },
+            },
+
+            showNsfw: {
+                deep: false,
+                handler() {
+                    this.resetDisplayPriority();
+                },
+            },
+
+            filterNsfw: {
+                deep: false,
+                handler() {
+                    this.resetDisplayPriority();
+                },
+            },
+        },
+
+        methods: {
+            runDisplayPriority() {
+                const step = () => {
+                    requestAnimationFrame(() => {
+                        this.displayPriority++;
+                        if (this.displayPriority < count) {
+                            step();
+                        }
+                    });
+                }
+                step();
+            },
+
+            defer(priority) {
+                return this.displayPriority >= priority;
+            },
+
+            resetDisplayPriority() {
+                this.displayPriority = 0;
+                this.runDisplayPriority();
+            }
+        },
+    };
+}

--- a/assets/Shuffle.js
+++ b/assets/Shuffle.js
@@ -1,0 +1,35 @@
+// Randomize array elements without mutating the original array using the 
+// Durstenfeld shuffle algorithm.
+export function shuffleArray(array) {
+    let shuffledArray = [...array];
+    for (let i = shuffledArray.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [shuffledArray[i], shuffledArray[j]] = [shuffledArray[j], shuffledArray[i]];
+    }
+    return shuffledArray;
+}
+
+// Randomize array elements without mutating the original array using a 
+// modification of Mike Bostock's implementation of the Fisher-Yates algorithm.
+export function shuffleArrayWithSeed(array, seed) {
+    let shuffledArray = [...array];
+    let toShuffleCount = shuffledArray.length;
+  
+    while (toShuffleCount) {
+        let randIndex = Math.floor(random(seed) * toShuffleCount--);
+  
+        let swapTmp = shuffledArray[toShuffleCount];
+        shuffledArray[toShuffleCount] = shuffledArray[randIndex];
+        shuffledArray[randIndex] = swapTmp;
+
+        ++seed;
+    }
+  
+    return shuffledArray;
+}
+
+function random(seed) {
+    let x = Math.sin(seed++) * 10000;
+    let r = x - Math.floor(x);
+    return r;
+}

--- a/components/Grid.vue
+++ b/components/Grid.vue
@@ -13,13 +13,23 @@
             :gutter="{ default: '30px' }"
         >
             <Thing
-                v-for="item in saved"
+                v-for="item in saved.slice(0, 100)"
                 :key="item.name"
                 :item="item"
                 :width="width"
                 :height-limit="heightLimit"
                 @observe="observe"
             />
+            <template v-if="defer(10)">
+                <Thing
+                    v-for="item in saved.slice(100, saved.length)"
+                    :key="item.name"
+                    :item="item"
+                    :width="width"
+                    :height-limit="heightLimit"
+                    @observe="observe"
+                />
+            </template>
         </masonry>
     </div>
 </template>
@@ -97,6 +107,7 @@
 <script>
     import Vue from 'vue';
     import Masonry from 'vue-masonry-css';
+    import Defer from "../assets/Defer";
 
     import Thing from './Thing.vue';
 
@@ -106,6 +117,9 @@
         components: {
             Thing,
         },
+        mixins: [
+            Defer(),
+        ],
         data() {
             return {
                 observer: null,

--- a/components/Menu.vue
+++ b/components/Menu.vue
@@ -250,6 +250,81 @@
             </div>
 
             <div class="menu__section menu__section-header">
+                Shuffle 
+                <small>
+                    Behavior for the shuffle button.
+                    Shuffling all posts in quick succession may impact performance
+                </small>
+            </div>
+
+            <div class="menu__section">
+                <button
+                    :class="[
+                        'button',
+                        'button--toggle',
+                        {
+                            'button--toggle-active': numShuffledPosts === -1,
+                        }
+                    ]"
+                    @click.prevent="setNumShuffledPosts(-1)"
+                >
+                    Shuffle all saved posts
+                </button>
+
+                <button
+                    :class="[
+                        'button',
+                        'button--toggle',
+                        {
+                            'button--toggle-active': numShuffledPosts !== -1,
+                        }
+                    ]"
+                    @click.prevent="setNumShuffledPosts(30)"
+                >
+                    Display a number of random posts
+                </button>
+
+                <input
+                    v-if="numShuffledPosts !== -1"
+                    v-model="numShuffledPosts"
+                    type="text"
+                    placeholder="Number of random posts to display..."
+                    class="menu__num-random-posts"
+                >
+            </div>
+
+            <div 
+                v-if="numShuffledPosts !== -1"
+                class="menu__section"
+            >
+                <button
+                    :class="[
+                        'button',
+                        'button--toggle',
+                        {
+                            'button--toggle-active': !trueRandomization,
+                        }
+                    ]"
+                    @click.prevent="setTrueRandomization(false)"
+                >
+                    Unique randomization
+                </button>
+
+                <button
+                    :class="[
+                        'button',
+                        'button--toggle',
+                        {
+                            'button--toggle-active': trueRandomization,
+                        }
+                    ]"
+                    @click.prevent="setTrueRandomization(true)"
+                >
+                    True randomization
+                </button>
+            </div>
+
+            <div class="menu__section menu__section-header">
                 Support
             </div>
 
@@ -423,10 +498,8 @@
         }
     }
 
-    .menu__filter-subreddit {
-        width: 100%;
-
-        height: 40px;
+    input {
+        height: 45px;
         padding: 0 20px;
 
         @include font-main();
@@ -442,7 +515,10 @@
         &:focus {
             outline: none;
         }
+    }
 
+    .menu__filter-subreddit {
+        width: 100%;
     }
 
     .menu__filter-clear {
@@ -472,6 +548,13 @@
 
         text-decoration: underline;
         text-underline-offset: 2px;
+    }
+
+    .menu__num-random-posts {
+        align-self: center;
+
+        width: 80px;
+        margin: 5px;
     }
 </style>
 
@@ -537,6 +620,22 @@
             theme() {
                 return this.$store.state.theme;
             },
+
+            numShuffledPosts: {
+                get() {
+                    return this.$store.state.numShuffledPosts;
+                },
+                set(num) {
+                    num = Math.floor(num.data || num);
+                    if (!isNaN(num)) {
+                        this.$store.dispatch('setNumShuffledPosts', num);
+                    }
+                }
+            },
+
+            trueRandomization() {
+                return this.$store.state.shuffleSeed === null;
+            },
         },
         methods: {
             close() {
@@ -573,6 +672,14 @@
 
             setTheme(theme) {
                 this.$store.dispatch('setTheme', theme);
+            },
+
+            setNumShuffledPosts(num) {
+                this.numShuffledPosts = num
+            },
+
+            setTrueRandomization(val) {
+                this.$store.dispatch('setTrueRandomization', val);
             },
         },
     };

--- a/components/Toolbar.vue
+++ b/components/Toolbar.vue
@@ -19,6 +19,42 @@
             </div>
 
             <button
+                v-if="numShuffles"
+                :class="[
+                    'toolbar__resetShuffle',
+                    'toolbar__extra-icon',
+                    {
+                        'toolbar__resetShuffle--loading': loading
+                    }
+                ]"
+                aria-label="Reset Shuffle"
+                @click.prevent="resetShuffle"
+            >
+                <i class="fas fa-ban" />
+                <span class="toolbar__tooltip">
+                    Reset shuffle
+                </span>
+            </button>
+
+            <button
+                v-if="!loading"
+                :class="[
+                    'toolbar__shuffle',
+                    'toolbar__extra-icon',
+                    {
+                        'toolbar__shuffle--loading': loading
+                    }
+                ]"
+                aria-label="Shuffle"
+                @click.prevent="shuffle"
+            >
+                <i class="fas fa-random" />
+                <span class="toolbar__tooltip">
+                    Shuffle posts
+                </span>
+            </button>
+
+            <button
                 :class="[
                     'toolbar__reload',
                     {
@@ -155,12 +191,14 @@
 
     .toolbar__reload, .toolbar__menu {
 
+    .toolbar__reload, .toolbar__menu, .toolbar__extra-icon {
         flex: 0 0 auto;
 
-        margin-left: 10px;
+        margin-left: 5px;
+        padding: 0;
 
-        width: 40px;
-        height: 40px;
+        width: 35px;
+        height: 35px;
 
         border: none;
         background: none;
@@ -170,8 +208,6 @@
 
     .toolbar__menu {
         position: relative;
-
-        margin-left: 0;
 
         &:after {
             content: '';
@@ -200,8 +236,6 @@
     }
 
     .toolbar__reload {
-        margin-left: 12px;
-
         &.toolbar__reload--loading {
             i {
                 opacity: 0.4;
@@ -212,6 +246,21 @@
                 animation-timing-function: linear;
             }
         }
+    }
+
+    @keyframes grow {
+        0% {
+            scale: 0;
+            margin-left: 0;
+        }
+        100% {
+            scale: 1;
+            margin-left: 12px;
+        }
+    } 
+
+    .toolbar__extra-icon {
+        animation: grow .1s;
     }
 </style>
 
@@ -264,6 +313,10 @@
                     }
                 }
             },
+
+            numShuffles() {
+                return this.$store.state.numShuffles;
+            },
         },
         mounted() {
             this.doSearchDebounce = debounce(this.doSearch, 250);
@@ -283,6 +336,14 @@
 
             reload() {
                 this.$store.dispatch('reload');
+            },
+
+            shuffle() {
+                this.$store.dispatch('shuffle');
+            },
+
+            resetShuffle() {
+                this.$store.dispatch('resetShuffle');
             },
         },
     };

--- a/components/Toolbar.vue
+++ b/components/Toolbar.vue
@@ -72,6 +72,9 @@
                     v-if="loading"
                     class="fas fa-circle-notch"
                 />
+                <span class="toolbar__tooltip">
+                    Reload posts
+                </span>
             </button>
 
             <button
@@ -80,6 +83,9 @@
                 @click.prevent="showMenu"
             >
                 <i class="fas fa-bars" />
+                <span class="toolbar__tooltip">
+                    Open Menu
+                </span>
             </button>
         </div>
     </div>
@@ -100,12 +106,6 @@
         z-index: 1;
     }
 
-    button {
-        color: var(--color-button-dark-text);
-        background: transparent;
-        border: none;
-    }
-
     .toolbar__controls {
         display: flex;
 
@@ -119,6 +119,8 @@
 
         justify-content: center;
         align-items: center;
+
+        @include font-main();
 
         @include respond-above(sm) {
             padding-left: 0;
@@ -150,7 +152,6 @@
         height: 40px;
         padding: 0 20px;
 
-        @include font-main();
         font-size: 18px;
         line-height: 40px;
 
@@ -183,13 +184,43 @@
         color: var(--color-button-text);
 
         span {
-            @include font-main();
             font-size: 16px;
             line-height: 1;
         }
     }
 
-    .toolbar__reload, .toolbar__menu {
+    .toolbar__tooltip {
+        position: absolute;
+        opacity: 0;
+        z-index: 2;
+
+        bottom: -25px;
+        left: 0px;
+
+        padding: 6px;
+
+        font-size: small;
+        white-space: nowrap;
+
+        border-radius: 5px;
+        color: var(--color-text-copy);
+        background-color: var(--color-background-faded);
+
+        transition: opacity .1s;
+    }
+
+    button {
+        position: relative;
+
+        color: var(--color-button-dark-text);
+        background: transparent;
+        border: none;
+
+        &:hover .toolbar__tooltip {
+            opacity: 1;
+            transition: opacity .1s linear 1s;
+        }
+    }
 
     .toolbar__reload, .toolbar__menu, .toolbar__extra-icon {
         flex: 0 0 auto;


### PR DESCRIPTION
This pull request implements the features requested in #23 and #48. Buy adding a shuffle button to the top of the page that shuffles the currently displaying posts, feature request #48 is implemented. By allowing the user to adjust in the menu how many posts are shown after a shuffle, feature request #23 is implemented.

As an additional improvement, I add the ability to choose between using true randomness posts and unique randomness when shuffling a certain number of posts. True randomness shuffles the posts with a true random number generator, so each time the user presses the shuffle button, new random posts will appear. Unique randomness shuffles the posts using a seed so that it can guarantee that every time the user shuffles the posts, no post is shown twice before every other post in the set has been shown. This is nice when the user is shuffling many posts but only wants to see a few at a time so they do not keep getting repeats.

This pull request also adds some deferring to the post rendering. This is to provide the user with the first 100 posts immediately upon first page render and when changing settings that change the posts displayed. It is a simple solution, but if further performance optimizations need to be done later, the deferring logic is not hard to rip out and replace.